### PR TITLE
fix(metro-plugin): substitute __DEV__ / process.env.NODE_ENV in inline pass

### DIFF
--- a/packages/core/src/swc.ts
+++ b/packages/core/src/swc.ts
@@ -83,6 +83,10 @@ function selectParser(filename: string, source: string): ExtendedParserConfig {
 // Environment / globals building blocks
 // ---------------------------------------------------------------------------
 
+function nodeEnvFor(dev: boolean): string {
+  return dev ? 'development' : 'production';
+}
+
 /**
  * Build the `jsc.transform.optimizer.globals` maps that drive the constant-
  * inline pass. Emits values as JSON strings so SWC pastes them verbatim
@@ -98,7 +102,7 @@ function buildOptimizerGlobals(
 
   const vars: Record<string, string> = { __DEV__: JSON.stringify(dev) };
   const envs: Record<string, string> = {
-    NODE_ENV: JSON.stringify(dev ? 'development' : 'production'),
+    NODE_ENV: JSON.stringify(nodeEnvFor(dev)),
     EXPO_OS: JSON.stringify(platform),
   };
 
@@ -207,6 +211,10 @@ interface PostTransformOptions {
   platform: string;
   nonInlinedRequires: string[];
   extraInlineableCalls: string[];
+  /** Substituted into the AST by the inline pass so the sibling
+   *  `constant_folding` pass can fold `if (__DEV__) …` branches. */
+  dev: boolean;
+  nodeEnv: string;
 }
 
 /**
@@ -264,6 +272,8 @@ export function runSwc(
     nonInlinedRequires: [...(options.nonInlinedRequires ?? [])],
     // SWC already handles interop inline; no extra helper calls are needed.
     extraInlineableCalls: [],
+    dev,
+    nodeEnv: nodeEnvFor(dev),
   };
 
   const swcOptions: SwcOptions = {
@@ -271,7 +281,7 @@ export function runSwc(
     // Surface NODE_ENV to SWC plugins via the plugin-env metadata, so e.g.
     // the worklets plugin can detect release mode with its upstream
     // `/(prod|release|stag[ei])/i` regex instead of a custom option.
-    envName: dev ? 'development' : 'production',
+    envName: nodeEnvFor(dev),
     swcrc: false,
     configFile: false,
     sourceMaps: true,

--- a/packages/metro-plugin/__tests__/inline.test.ts
+++ b/packages/metro-plugin/__tests__/inline.test.ts
@@ -7,7 +7,7 @@
  * compatibility, not the inline plugin itself).
  */
 
-import { compareInline } from './test-helpers';
+import { compareInline, compareInlineThenFold } from './test-helpers';
 
 describe('inline constants', () => {
   test('replaces Platform.OS in the code if Platform is a global', () => {
@@ -675,5 +675,164 @@ describe('inline constants', () => {
       platform: 'android',
       isWrapped: true,
     });
+  });
+});
+
+describe('dev / NODE_ENV substitution', () => {
+  test('replaces __DEV__ with the dev option literal', () => {
+    const code = `
+      if (__DEV__) require('./d'); else require('./p');
+    `;
+    const expected = `
+      if (false) require('./d'); else require('./p');
+    `;
+    compareInline(code, expected, { dev: false });
+  });
+
+  test('replaces __DEV__ with true when dev: true', () => {
+    const code = `var x = __DEV__;`;
+    const expected = `var x = true;`;
+    compareInline(code, expected, { dev: true });
+  });
+
+  test('replaces process.env.NODE_ENV with the nodeEnv string literal', () => {
+    const code = `
+      if (process.env.NODE_ENV !== 'production') { foo(); }
+    `;
+    const expected = `
+      if ("production" !== 'production') { foo(); }
+    `;
+    compareInline(code, expected, { nodeEnv: 'production' });
+  });
+
+  test('does not substitute __DEV__ when locally shadowed', () => {
+    const code = `
+      function f() {
+        var __DEV__ = "x";
+        return __DEV__;
+      }
+    `;
+    compareInline(code, code, { dev: false });
+  });
+
+  test('does not substitute process.env.NODE_ENV when process is locally shadowed', () => {
+    const code = `
+      function f() {
+        var process = { env: { NODE_ENV: 'shadow' } };
+        return process.env.NODE_ENV;
+      }
+    `;
+    compareInline(code, code, { nodeEnv: 'production' });
+  });
+
+  test('does not substitute __DEV__ when dev option is undefined (default)', () => {
+    const code = `
+      if (__DEV__) require('./d'); else require('./p');
+    `;
+    compareInline(code, code, {});
+  });
+
+  test('does not substitute process.env.NODE_ENV when nodeEnv option is undefined (default)', () => {
+    const code = `
+      if (process.env.NODE_ENV !== 'production') { foo(); }
+    `;
+    compareInline(code, code, {});
+  });
+
+  test('does not touch the LHS of an assignment to __DEV__', () => {
+    // Visitor only descends into the RHS of assignments — assignment to a
+    // shadow-style `__DEV__` should round-trip even when dev substitution is
+    // requested.
+    const code = `
+      function f() {
+        var __DEV__;
+        __DEV__ = 1;
+      }
+    `;
+    compareInline(code, code, { dev: false });
+  });
+
+  test('does not touch the LHS of an assignment to __DEV__ without a shadow declaration', () => {
+    // Same LHS-skip mechanism, but here there's no `var __DEV__` shadow at
+    // all — so this isolates `visit_mut_assign_expr`'s RHS-only descent.
+    const code = `
+      function f() {
+        __DEV__ = 1;
+      }
+    `;
+    compareInline(code, code, { dev: false });
+  });
+
+  test('does not touch the LHS of an assignment to process.env.NODE_ENV', () => {
+    const code = `
+      function f() {
+        process.env.NODE_ENV = "test";
+      }
+    `;
+    compareInline(code, code, { nodeEnv: 'production' });
+  });
+
+  test("replaces process.env.NODE_ENV with 'development' when nodeEnv is 'development'", () => {
+    const code = `
+      if (process.env.NODE_ENV === 'development') { foo(); }
+    `;
+    const expected = `
+      if ("development" === 'development') { foo(); }
+    `;
+    compareInline(code, expected, { nodeEnv: 'development' });
+  });
+
+  test('inline + constantFolding eliminates the dev require branch', () => {
+    const code = `
+      var ReactFabric;
+      if (__DEV__) {
+        ReactFabric = require('./ReactFabric-dev');
+      } else {
+        ReactFabric = require('./ReactFabric-prod');
+      }
+    `;
+    const expected = `
+      var ReactFabric;
+      {
+        ReactFabric = require('./ReactFabric-prod');
+      }
+    `;
+    compareInlineThenFold(code, expected, { dev: false });
+  });
+
+  test('inline + constantFolding keeps the dev branch when dev: true', () => {
+    const code = `
+      var ReactFabric;
+      if (__DEV__) {
+        ReactFabric = require('./ReactFabric-dev');
+      } else {
+        ReactFabric = require('./ReactFabric-prod');
+      }
+    `;
+    const expected = `
+      var ReactFabric;
+      {
+        ReactFabric = require('./ReactFabric-dev');
+      }
+    `;
+    compareInlineThenFold(code, expected, { dev: true });
+  });
+
+  test('inline + constantFolding eliminates a dev-only side-effect require', () => {
+    const code = `
+      if (__DEV__) {
+        require('react-devtools-core').connectToDevTools({ host: 'localhost' });
+      }
+    `;
+    compareInlineThenFold(code, '', { dev: false });
+  });
+
+  test('inline + constantFolding folds a NODE_ENV branch', () => {
+    const code = `
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('dev only');
+      }
+    `;
+    compareInlineThenFold(code, '', { nodeEnv: 'production' });
   });
 });

--- a/packages/metro-plugin/__tests__/run-pass.ts
+++ b/packages/metro-plugin/__tests__/run-pass.ts
@@ -15,6 +15,10 @@ export interface InlineOptions {
   inlinePlatform?: boolean;
   platform?: string;
   isWrapped?: boolean;
+  /** When set, replace `__DEV__` with this boolean literal in the inline pass. */
+  dev?: boolean;
+  /** When set, replace `process.env.NODE_ENV` with this string literal in the inline pass. */
+  nodeEnv?: string;
 }
 
 export interface InlineRequiresOptions {
@@ -28,19 +32,24 @@ type PassOpts =
   | { pass: 'experimentalImports' }
   | ({ pass: 'inline' } & InlineOptions)
   | ({ pass: 'inlineRequires' } & InlineRequiresOptions)
-  | { pass: 'constantFolding' };
+  | { pass: 'constantFolding' }
+  | ({ pass: 'inlineThenFold' } & InlineOptions);
 
 function pluginOptions(opts: PassOpts): Record<string, unknown> {
   switch (opts.pass) {
     case 'experimentalImports':
       return { experimentalImports: true };
-    case 'inline':
-      return {
+    case 'inline': {
+      const base: Record<string, unknown> = {
         inline: true,
         inlinePlatform: opts.inlinePlatform ?? false,
         platform: opts.platform ?? '',
         isWrapped: opts.isWrapped ?? false,
       };
+      if (opts.dev !== undefined) base.dev = opts.dev;
+      if (opts.nodeEnv !== undefined) base.nodeEnv = opts.nodeEnv;
+      return base;
+    }
     case 'inlineRequires':
       return {
         inlineRequires: true,
@@ -51,6 +60,18 @@ function pluginOptions(opts: PassOpts): Record<string, unknown> {
       };
     case 'constantFolding':
       return { constantFolding: true };
+    case 'inlineThenFold': {
+      const base: Record<string, unknown> = {
+        inline: true,
+        constantFolding: true,
+        inlinePlatform: opts.inlinePlatform ?? false,
+        platform: opts.platform ?? '',
+        isWrapped: opts.isWrapped ?? false,
+      };
+      if (opts.dev !== undefined) base.dev = opts.dev;
+      if (opts.nodeEnv !== undefined) base.nodeEnv = opts.nodeEnv;
+      return base;
+    }
   }
 }
 

--- a/packages/metro-plugin/__tests__/test-helpers.ts
+++ b/packages/metro-plugin/__tests__/test-helpers.ts
@@ -31,3 +31,16 @@ export function compareInlineRequires(
   const actual = format(runPass(code, { pass: 'inlineRequires', ...options }));
   expect(actual).toBe(format(expected));
 }
+
+/** Run inline + constantFolding in a single plugin invocation as they
+ *  appear back-to-back in the production pipeline (omitting the surrounding
+ *  experimentalImports / inlineRequires passes), so we can assert that
+ *  `if (__DEV__)` branches collapse to just the live arm. */
+export function compareInlineThenFold(
+  code: string,
+  expected: string,
+  options?: InlineOptions,
+): void {
+  const actual = format(runPass(code, { pass: 'inlineThenFold', ...options }));
+  expect(actual).toBe(format(expected));
+}

--- a/packages/metro-plugin/crates/metro_plugin/benches/inline.rs
+++ b/packages/metro-plugin/crates/metro_plugin/benches/inline.rs
@@ -47,6 +47,8 @@ fn bench(c: &mut Criterion) {
                         is_wrapped: false,
                         require_name: "require".into(),
                         platform: "ios".into(),
+                        dev: None,
+                        node_env: None,
                     },
                 );
                 program
@@ -65,6 +67,30 @@ fn bench(c: &mut Criterion) {
                         is_wrapped: true,
                         require_name: "require".into(),
                         platform: "ios".into(),
+                        dev: None,
+                        node_env: None,
+                    },
+                );
+                program
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    // Variant that exercises the `__DEV__` / `process.env.NODE_ENV`
+    // substitution paths so regressions in those branches surface in CI.
+    group.bench_function("ios_unwrapped_with_dev_and_node_env", |b| {
+        b.iter_batched(
+            || parsed.clone(),
+            |mut program| {
+                inline_plugin(
+                    &mut program,
+                    &Options {
+                        inline_platform: true,
+                        is_wrapped: false,
+                        require_name: "require".into(),
+                        platform: "ios".into(),
+                        dev: Some(false),
+                        node_env: Some("production".into()),
                     },
                 );
                 program

--- a/packages/metro-plugin/crates/metro_plugin/benches/pipeline.rs
+++ b/packages/metro-plugin/crates/metro_plugin/benches/pipeline.rs
@@ -48,6 +48,10 @@ fn run_pipeline(mut program: swc_core::ecma::ast::Program) -> swc_core::ecma::as
             is_wrapped: false,
             require_name: "require".into(),
             platform: "ios".into(),
+            // Production always sets these, so the pipeline bench measures
+            // the same code path Metro hits.
+            dev: Some(false),
+            node_env: Some("production".into()),
         },
     );
     inline_requires::inline_requires(&mut program, &inline_requires::Options::default());

--- a/packages/metro-plugin/crates/metro_plugin/src/inline.rs
+++ b/packages/metro-plugin/crates/metro_plugin/src/inline.rs
@@ -9,6 +9,13 @@ pub struct Options {
     pub is_wrapped: bool,
     pub require_name: String,
     pub platform: String,
+    /// When `Some(b)`, replace every non-shadowed `__DEV__` Identifier with
+    /// the boolean literal `b`. When `None`, leave `__DEV__` alone (relying
+    /// on a downstream pass — e.g. SWC's optimizer.globals — to substitute).
+    pub dev: Option<bool>,
+    /// When `Some(s)`, replace every non-shadowed `process.env.NODE_ENV`
+    /// MemberExpr with the string literal `s`. When `None`, leave it alone.
+    pub node_env: Option<String>,
 }
 
 /// Apply inline replacements: __DEV__, Platform.OS, Platform.select, process.env.NODE_ENV.
@@ -202,6 +209,26 @@ impl<'a> InlineVisitor<'a> {
         self.local_scopes.iter().any(|s| s.contains(name))
     }
 
+    /// Match `process.env.NODE_ENV` where `process` is a non-shadowed Identifier
+    /// (i.e. refers to the global). `env` and `NODE_ENV` are property accesses,
+    /// not bindings — only `process` itself can be shadowed. `var env = x` does
+    /// not affect `process.env`.
+    fn is_process_env_node_env(&self, member: &MemberExpr) -> bool {
+        if !is_prop_ident(&member.prop, "NODE_ENV") {
+            return false;
+        }
+        let Expr::Member(inner) = member.obj.as_ref() else {
+            return false;
+        };
+        if !is_prop_ident(&inner.prop, "env") {
+            return false;
+        }
+        match inner.obj.as_ref() {
+            Expr::Ident(id) => id.sym.as_ref() == "process" && !self.is_locally_shadowed(&id.sym),
+            _ => false,
+        }
+    }
+
     fn declare_local(&mut self, name: Atom) {
         if let Some(scope) = self.local_scopes.last_mut() {
             scope.insert(name);
@@ -271,11 +298,25 @@ impl<'a> InlineVisitor<'a> {
     }
 
     fn try_inline(&mut self, expr: &mut Expr) -> bool {
-        // Note: `__DEV__` and `process.env.NODE_ENV` are handled in
-        // production by SWC's optimizer globals/envs (configured in
-        // `src/swc.ts`). This pass only needs to cover the Platform
-        // substitutions that the optimizer can't express.
+        // `__DEV__` and `process.env.NODE_ENV` are substituted here when the
+        // caller asks for it (`opts.dev` / `opts.node_env` set). Doing it
+        // inside this pass — instead of leaving it to SWC's later
+        // `optimizer.globals` step — means subsequent sibling passes in the
+        // same plugin invocation (notably `constant_folding`) get to see the
+        // resulting literals and can fold `if (false) require('./dev')`
+        // branches away. The `optimizer.globals` substitution still runs
+        // afterwards as a safety belt for any path that bypasses this opt-in.
         match expr {
+            Expr::Ident(id) => {
+                if let Some(value) = self.opts.dev {
+                    if id.sym.as_ref() == "__DEV__" && !self.is_locally_shadowed(&id.sym) {
+                        *expr = bool_lit(value);
+                        return true;
+                    }
+                }
+                false
+            }
+
             Expr::Member(member) => {
                 if is_prop_ident(&member.prop, "OS")
                     && self.opts.inline_platform
@@ -284,6 +325,12 @@ impl<'a> InlineVisitor<'a> {
                     let s = self.opts.platform.clone();
                     *expr = str_lit(&s);
                     return true;
+                }
+                if let Some(node_env) = self.opts.node_env.as_deref() {
+                    if self.is_process_env_node_env(member) {
+                        *expr = str_lit(node_env);
+                        return true;
+                    }
                 }
                 false
             }
@@ -468,6 +515,13 @@ fn str_lit(s: &str) -> Expr {
         span: DUMMY_SP,
         value: Atom::from(s).into(),
         raw: None,
+    }))
+}
+
+fn bool_lit(value: bool) -> Expr {
+    Expr::Lit(Lit::Bool(Bool {
+        span: DUMMY_SP,
+        value,
     }))
 }
 

--- a/packages/metro-plugin/crates/metro_plugin/src/wasm_plugin.rs
+++ b/packages/metro-plugin/crates/metro_plugin/src/wasm_plugin.rs
@@ -24,6 +24,13 @@ struct PostTransformPluginOptions {
     inline_platform: bool,
     platform: String,
     is_wrapped: bool,
+    /// `__DEV__` substitution for the inline pass. `Some(b)` substitutes;
+    /// `None` (default) leaves `__DEV__` as an Identifier so a downstream
+    /// optimizer pass can handle it.
+    dev: Option<bool>,
+    /// `process.env.NODE_ENV` substitution for the inline pass. Same opt-in
+    /// semantics as `dev`.
+    node_env: Option<String>,
 
     // Inline-requires configuration.
     non_inlined_requires: Vec<String>,
@@ -57,6 +64,8 @@ pub fn process_transform(
                 is_wrapped: options.is_wrapped,
                 require_name: "require".to_string(),
                 platform: options.platform,
+                dev: options.dev,
+                node_env: options.node_env.clone(),
             },
         );
     }


### PR DESCRIPTION
Closes #3.

## Summary

`constantFolding` runs before SWC's `optimizer.globals.vars` in the plugin pipeline, so `if (__DEV__)` reaches it as an `Identifier` and the dead branch isn't folded. Dev-only `require()` calls survive Metro's dependency walker → ~600 KB of dev React renderers leak into production iOS Hermes bundles.

This moves `__DEV__` and `process.env.NODE_ENV` substitution into the `inline` pass, so subsequent `constantFolding` (in the same plugin invocation) sees literals.

See #3 for the full root-cause analysis, repro, and impact measurements.

## Changes

- `crates/metro_plugin/src/inline.rs`: extend `Options` with `dev: Option<bool>` and `node_env: Option<String>`; substitute `__DEV__` Ident and `process.env.NODE_ENV` Member in `try_inline` (with shadow protection).
- `crates/metro_plugin/src/wasm_plugin.rs`: add `dev` and `node_env` fields, thread to `inline::Options`.
- `packages/core/src/swc.ts`: pass `dev` and `nodeEnv` in `postTransformOptions`. Existing `optimizer.globals` substitution kept as a safety belt.
- Tests: 12 new cases (substitution, shadow, default no-op, integration); new `compareInlineThenFold` helper. All 95 pre-existing tests pass.
- Benches updated to construct the wider `inline::Options` struct.

## Test plan

- [x] `pnpm --filter @react-native-swc/metro-plugin test` — 107/107 pass
- [x] e2e: `if (__DEV__) require('./d'); else require('./p')` with the freshly built wasm and `dev: false` → only `require('./p')` survives
- [x] Real-app verification: representative Expo 54 / Hermes iOS bundle drops from ~18.2 MB → ~17.6 MB; the four leaked dev modules (`ReactFabric-dev`, `ReactNativeRenderer-dev`, `react-devtools-core`, `react.development`) all disappear from the dependency graph.
