### PR TITLE
Replace __DEV__ and process.env in metro plugin

### DIFF
--- a/packages/core/src/swc.ts
+++ b/packages/core/src/swc.ts
@@ -84,26 +84,31 @@ function selectParser(filename: string, source: string): ExtendedParserConfig {
 // ---------------------------------------------------------------------------
 
 /**
- * Build the `jsc.transform.optimizer.globals` maps that drive the constant-
- * inline pass. Emits values as JSON strings so SWC pastes them verbatim
- * into the AST — e.g. `{ API_URL: "https://x" }` becomes a StringLiteral.
+ * Build the `process.env.<KEY>` substitution map handed to the metro-plugin's
+ * inline pass. Values are unescaped raw strings — the plugin emits each as
+ * a `Lit::Str` directly, so `{ API_URL: "https://x" }` replaces
+ * `process.env.API_URL` with the literal `"https://x"`.
+ *
+ * Lives next to (and intentionally fed alongside) the `dev` flag because
+ * `__DEV__` and `process.env.NODE_ENV` are part of the same Metro contract:
+ * both are inlined at compile time so downstream constant folding can
+ * eliminate dead branches.
  */
-function buildOptimizerGlobals(
+function buildInlineEnvs(
   options: JsTransformOptions,
   filename: string,
   userConfig: SwcTransformerOptions | undefined,
-): { vars: Record<string, string>; envs: Record<string, string> } {
+): Record<string, string> {
   const { dev, platform, customTransformOptions } = options;
   const projectRoot = (options as unknown as { projectRoot?: string }).projectRoot;
 
-  const vars: Record<string, string> = { __DEV__: JSON.stringify(dev) };
   const envs: Record<string, string> = {
-    NODE_ENV: JSON.stringify(dev ? 'development' : 'production'),
-    EXPO_OS: JSON.stringify(platform),
+    NODE_ENV: dev ? 'development' : 'production',
+    EXPO_OS: platform ?? '',
   };
 
   if (projectRoot) {
-    envs.EXPO_PROJECT_ROOT = JSON.stringify(projectRoot);
+    envs.EXPO_PROJECT_ROOT = projectRoot;
 
     const routerRoot =
       typeof customTransformOptions?.routerRoot === 'string'
@@ -114,18 +119,18 @@ function buildOptimizerGlobals(
       customTransformOptions?.asyncRoutes === true;
     const absAppRoot = join(projectRoot, routerRoot);
 
-    envs.EXPO_ROUTER_APP_ROOT = JSON.stringify(relative(dirname(filename), absAppRoot));
-    envs.EXPO_ROUTER_ABS_APP_ROOT = JSON.stringify(absAppRoot);
-    envs.EXPO_ROUTER_IMPORT_MODE = JSON.stringify(asyncRoutes ? 'lazy' : 'sync');
+    envs.EXPO_ROUTER_APP_ROOT = relative(dirname(filename), absAppRoot);
+    envs.EXPO_ROUTER_ABS_APP_ROOT = absAppRoot;
+    envs.EXPO_ROUTER_IMPORT_MODE = asyncRoutes ? 'lazy' : 'sync';
   }
 
   if (userConfig?.envs) {
     for (const [k, v] of Object.entries(userConfig.envs)) {
-      envs[k] = JSON.stringify(v);
+      envs[k] = v;
     }
   }
 
-  return { vars, envs };
+  return envs;
 }
 
 // ---------------------------------------------------------------------------
@@ -205,6 +210,8 @@ interface PostTransformOptions {
   constantFolding: boolean;
   inlinePlatform: boolean;
   platform: string;
+  dev: boolean;
+  envs: Record<string, string>;
   nonInlinedRequires: string[];
   extraInlineableCalls: string[];
 }
@@ -243,7 +250,7 @@ export function runSwc(
   userConfig: SwcTransformerOptions | undefined,
 ): { code: string; map: MetroSourceMapSegmentTuple[] } {
   const { dev } = options;
-  const { vars, envs } = buildOptimizerGlobals(options, filename, userConfig);
+  const envs = buildInlineEnvs(options, filename, userConfig);
 
   const reactConfig: ReactConfig = {
     runtime: 'automatic',
@@ -261,6 +268,8 @@ export function runSwc(
     constantFolding: !dev,
     inlinePlatform: options.inlinePlatform,
     platform: options.platform ?? '',
+    dev,
+    envs,
     nonInlinedRequires: [...(options.nonInlinedRequires ?? [])],
     // SWC already handles interop inline; no extra helper calls are needed.
     extraInlineableCalls: [],
@@ -297,7 +306,6 @@ export function runSwc(
       },
       transform: {
         react: reactConfig,
-        optimizer: { globals: { vars, envs } },
       },
       externalHelpers: false,
     },

--- a/packages/metro-plugin/__tests__/inline.test.ts
+++ b/packages/metro-plugin/__tests__/inline.test.ts
@@ -676,4 +676,184 @@ describe('inline constants', () => {
       isWrapped: true,
     });
   });
+
+  describe('__DEV__', () => {
+    test('replaces __DEV__ in the code', () => {
+      const code = `
+        function a() {
+          var a = __DEV__ ? 1 : 2;
+          var b = a.__DEV__;
+          var c = function __DEV__(__DEV__) {};
+        }
+      `;
+
+      compareInline(code, code.replace(/__DEV__/, 'false'), { dev: false });
+    });
+
+    test("doesn't replace a local __DEV__ variable", () => {
+      const code = `
+        function a() {
+          var __DEV__ = false;
+          var a = __DEV__ ? 1 : 2;
+        }
+      `;
+
+      compareInline(code, code, { dev: false });
+    });
+
+    test("doesn't replace __DEV__ in an object property key", () => {
+      const code = `
+        const x = { __DEV__: __DEV__ };
+      `;
+
+      const expected = `
+        const x = { __DEV__: false };
+      `;
+
+      compareInline(code, expected, { dev: false });
+    });
+
+    test("doesn't replace __DEV__ in an object shorthand method name", () => {
+      const code = `
+        const x = {
+          __DEV__() { return __DEV__; },
+        };
+      `;
+
+      const expected = `
+        const x = {
+          __DEV__() { return false; },
+        };
+      `;
+
+      compareInline(code, expected, { dev: false });
+    });
+
+    test("doesn't replace __DEV__ as a label of a block statement", () => {
+      const code = `
+        __DEV__: {
+          break __DEV__;
+        };
+      `;
+
+      compareInline(code, code, { dev: false });
+    });
+
+    test("doesn't replace __DEV__ as the name of a function declaration or call", () => {
+      const code = `
+        function __DEV__() { return false; }
+        const isDev = __DEV__();
+      `;
+
+      compareInline(code, code, { dev: false });
+    });
+
+    test("doesn't replace __DEV__ as the name of a class method", () => {
+      const code = `
+        class Test {
+          __DEV__() {}
+        }
+      `;
+
+      compareInline(code, code, { dev: false });
+    });
+
+    test("doesn't replace __DEV__ as the name of an export alias", () => {
+      const code = `
+        const dev = true;
+        export { dev as __DEV__ };
+      `;
+
+      compareInline(code, code, { dev: false });
+    });
+
+    test("doesn't replace __DEV__ as the name of an optional property access", () => {
+      const code = `
+        x?.__DEV__;
+        x?.__DEV__();
+      `;
+
+      compareInline(code, code, { dev: false });
+    });
+
+    test('replaces __DEV__ with `true` in dev mode', () => {
+      const code = `var a = __DEV__;`;
+      compareInline(code, `var a = true;`, { dev: true });
+    });
+  });
+
+  describe('process.env', () => {
+    test('replaces process.env.NODE_ENV in the code', () => {
+      const code = `
+        function a() {
+          if (process.env.NODE_ENV === 'production') {
+            return require('Prod');
+          }
+
+          return require('Dev');
+        }
+      `;
+
+      compareInline(code, code.replace(/process\.env\.NODE_ENV/, '"production"'), {
+        dev: false,
+        envs: { NODE_ENV: 'production' },
+      });
+    });
+
+    test("doesn't replace process.env.NODE_ENV when it is the LHS of an assignment", () => {
+      const code = `
+        function a() {
+          process.env.NODE_ENV = 'production';
+        }
+      `;
+
+      compareInline(code, code, { dev: false, envs: { NODE_ENV: 'production' } });
+    });
+
+    test('replaces process.env.NODE_ENV when it is the RHS of an assignment', () => {
+      const code = `
+        function a() {
+          var env;
+          env = process.env.NODE_ENV;
+        }
+      `;
+
+      compareInline(code, code.replace(/process\.env\.NODE_ENV/, '"production"'), {
+        dev: false,
+        envs: { NODE_ENV: 'production' },
+      });
+    });
+
+    test('replaces user-supplied process.env.<KEY> entries', () => {
+      const code = `
+        const url = process.env.API_URL;
+        const region = process.env.REGION;
+      `;
+      const expected = `
+        const url = "https://example.com";
+        const region = "eu-west";
+      `;
+
+      compareInline(code, expected, {
+        dev: false,
+        envs: { API_URL: 'https://example.com', REGION: 'eu-west' },
+      });
+    });
+
+    test('does not replace process.env.<KEY> when the key is not configured', () => {
+      const code = `const x = process.env.UNKNOWN;`;
+      compareInline(code, code, { dev: false, envs: { NODE_ENV: 'production' } });
+    });
+
+    test('does not replace process.env.<KEY> when process is locally shadowed', () => {
+      const code = `
+        function a() {
+          var process = { env: { NODE_ENV: 'staging' } };
+          return process.env.NODE_ENV;
+        }
+      `;
+
+      compareInline(code, code, { dev: false, envs: { NODE_ENV: 'production' } });
+    });
+  });
 });

--- a/packages/metro-plugin/__tests__/run-pass.ts
+++ b/packages/metro-plugin/__tests__/run-pass.ts
@@ -15,6 +15,8 @@ export interface InlineOptions {
   inlinePlatform?: boolean;
   platform?: string;
   isWrapped?: boolean;
+  dev?: boolean;
+  envs?: Record<string, string>;
 }
 
 export interface InlineRequiresOptions {
@@ -40,6 +42,8 @@ function pluginOptions(opts: PassOpts): Record<string, unknown> {
         inlinePlatform: opts.inlinePlatform ?? false,
         platform: opts.platform ?? '',
         isWrapped: opts.isWrapped ?? false,
+        dev: opts.dev ?? false,
+        envs: opts.envs ?? {},
       };
     case 'inlineRequires':
       return {

--- a/packages/metro-plugin/crates/metro_plugin/benches/inline.rs
+++ b/packages/metro-plugin/crates/metro_plugin/benches/inline.rs
@@ -1,6 +1,14 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use rustc_hash::FxHashMap;
+use swc_core::atoms::Atom;
 
 use metro_plugin::inline::{inline_plugin, Options};
+
+fn make_envs() -> FxHashMap<Atom, String> {
+    let mut envs = FxHashMap::default();
+    envs.insert(Atom::from("NODE_ENV"), "production".into());
+    envs
+}
 
 #[path = "common.rs"]
 mod common;
@@ -47,6 +55,8 @@ fn bench(c: &mut Criterion) {
                         is_wrapped: false,
                         require_name: "require".into(),
                         platform: "ios".into(),
+                        dev: false,
+                        envs: make_envs(),
                     },
                 );
                 program
@@ -65,6 +75,8 @@ fn bench(c: &mut Criterion) {
                         is_wrapped: true,
                         require_name: "require".into(),
                         platform: "ios".into(),
+                        dev: false,
+                        envs: make_envs(),
                     },
                 );
                 program

--- a/packages/metro-plugin/crates/metro_plugin/benches/pipeline.rs
+++ b/packages/metro-plugin/crates/metro_plugin/benches/pipeline.rs
@@ -3,6 +3,8 @@
 // total contribution to a single file's transform.
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use rustc_hash::FxHashMap;
+use swc_core::atoms::Atom;
 
 use metro_plugin::{constant_folding, experimental_imports, inline, inline_requires};
 
@@ -41,6 +43,8 @@ export const Tag = "screen";
 
 fn run_pipeline(mut program: swc_core::ecma::ast::Program) -> swc_core::ecma::ast::Program {
     experimental_imports::rewrite_imports(&mut program);
+    let mut envs: FxHashMap<Atom, String> = FxHashMap::default();
+    envs.insert(Atom::from("NODE_ENV"), "production".into());
     inline::inline_plugin(
         &mut program,
         &inline::Options {
@@ -48,6 +52,8 @@ fn run_pipeline(mut program: swc_core::ecma::ast::Program) -> swc_core::ecma::as
             is_wrapped: false,
             require_name: "require".into(),
             platform: "ios".into(),
+            dev: false,
+            envs,
         },
     );
     inline_requires::inline_requires(&mut program, &inline_requires::Options::default());

--- a/packages/metro-plugin/crates/metro_plugin/src/inline.rs
+++ b/packages/metro-plugin/crates/metro_plugin/src/inline.rs
@@ -9,9 +9,16 @@ pub struct Options {
     pub is_wrapped: bool,
     pub require_name: String,
     pub platform: String,
+    /// Drives `__DEV__` substitution: every unshadowed reference becomes
+    /// this boolean literal.
+    pub dev: bool,
+    /// `process.env.<KEY>` → string-literal map. Values are inserted as
+    /// `Lit::Str` exactly, so callers should pass the unescaped string.
+    /// `NODE_ENV` is just a key in here — there is no separate path for it.
+    pub envs: FxHashMap<Atom, String>,
 }
 
-/// Apply inline replacements: __DEV__, Platform.OS, Platform.select, process.env.NODE_ENV.
+/// Apply inline replacements: __DEV__, Platform.OS, Platform.select, process.env.<KEY>.
 /// Mirrors Metro's `inline-plugin.js`.
 pub fn inline_plugin(program: &mut Program, opts: &Options) {
     let top_level_bindings = scan_top_level_bindings(program, opts);
@@ -271,11 +278,23 @@ impl<'a> InlineVisitor<'a> {
     }
 
     fn try_inline(&mut self, expr: &mut Expr) -> bool {
-        // Note: `__DEV__` and `process.env.NODE_ENV` are handled in
-        // production by SWC's optimizer globals/envs (configured in
-        // `src/swc.ts`). This pass only needs to cover the Platform
-        // substitutions that the optimizer can't express.
         match expr {
+            // `__DEV__` → boolean literal (when not shadowed). Matches
+            // Metro's inline-plugin: only bare references in expression
+            // position are rewritten — property keys, function/parameter
+            // names, optional-chain props, etc. live in non-Expr positions
+            // and are skipped by SWC's traversal automatically.
+            Expr::Ident(id) => {
+                if id.sym.as_ref() == "__DEV__" && !self.is_locally_shadowed(&id.sym) {
+                    *expr = Expr::Lit(Lit::Bool(Bool {
+                        span: DUMMY_SP,
+                        value: self.opts.dev,
+                    }));
+                    return true;
+                }
+                false
+            }
+
             Expr::Member(member) => {
                 if is_prop_ident(&member.prop, "OS")
                     && self.opts.inline_platform
@@ -284,6 +303,16 @@ impl<'a> InlineVisitor<'a> {
                     let s = self.opts.platform.clone();
                     *expr = str_lit(&s);
                     return true;
+                }
+                // `process.env.<KEY>` → string literal. We don't replace the
+                // LHS of an assignment (`process.env.X = ...`) because
+                // `visit_mut_assign_expr` only descends into the RHS.
+                if let Some(key) = self.try_match_process_env(member) {
+                    if let Some(value) = self.opts.envs.get(&key) {
+                        let s = value.clone();
+                        *expr = str_lit(&s);
+                        return true;
+                    }
                 }
                 false
             }
@@ -300,6 +329,32 @@ impl<'a> InlineVisitor<'a> {
 
             _ => false,
         }
+    }
+
+    /// Match `process.env.<KEY>` and return `<KEY>` as an Atom. Returns
+    /// `None` if `process` is locally shadowed, the chain is optional, or
+    /// any segment isn't a static identifier property.
+    fn try_match_process_env(&self, member: &MemberExpr) -> Option<Atom> {
+        let key = match &member.prop {
+            MemberProp::Ident(id) => id.sym.clone(),
+            _ => return None,
+        };
+        let inner = match member.obj.as_ref() {
+            Expr::Member(m) => m,
+            _ => return None,
+        };
+        if !is_prop_ident(&inner.prop, "env") {
+            return None;
+        }
+        match inner.obj.as_ref() {
+            Expr::Ident(id) if id.sym.as_ref() == "process" => {
+                if self.is_locally_shadowed(&id.sym) {
+                    return None;
+                }
+            }
+            _ => return None,
+        }
+        Some(key)
     }
 
     fn try_platform_select(&self, call: &CallExpr) -> Option<Expr> {

--- a/packages/metro-plugin/crates/metro_plugin/src/wasm_plugin.rs
+++ b/packages/metro-plugin/crates/metro_plugin/src/wasm_plugin.rs
@@ -1,7 +1,11 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
+use std::collections::HashMap;
+
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use swc_core::{
+    atoms::Atom,
     ecma::ast::Program,
     plugin::{plugin_transform, proxies::TransformPluginProgramMetadata},
 };
@@ -24,6 +28,12 @@ struct PostTransformPluginOptions {
     inline_platform: bool,
     platform: String,
     is_wrapped: bool,
+    /// Drives `__DEV__` substitution inside the inline pass.
+    dev: bool,
+    /// `process.env.<KEY>` → string-literal values inlined by the inline
+    /// pass. Owns `NODE_ENV` (callers set it to `"development"` /
+    /// `"production"`) so the same plumbing covers user-defined env vars.
+    envs: HashMap<String, String>,
 
     // Inline-requires configuration.
     non_inlined_requires: Vec<String>,
@@ -50,6 +60,10 @@ pub fn process_transform(
     }
 
     if options.inline {
+        let mut envs: FxHashMap<Atom, String> = FxHashMap::default();
+        for (k, v) in options.envs {
+            envs.insert(Atom::from(k.as_str()), v);
+        }
         inline::inline_plugin(
             &mut program,
             &inline::Options {
@@ -57,6 +71,8 @@ pub fn process_transform(
                 is_wrapped: options.is_wrapped,
                 require_name: "require".to_string(),
                 platform: options.platform,
+                dev: options.dev,
+                envs,
             },
         );
     }


### PR DESCRIPTION
Before it was replaced by the built in optimiser pass, which happens _after_ the constant folding plugin runs, which means some code paths simply weren't folded. 

Fixes #3
Supersedes #4 