### PR TITLE
fix: inline Expo app manifest env

### DIFF
--- a/packages/core/__tests__/transform-worker.test.ts
+++ b/packages/core/__tests__/transform-worker.test.ts
@@ -12,8 +12,12 @@
  */
 
 import { Buffer } from 'node:buffer';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { transformSync } from '@swc/core';
 import { transform, transformRequires, collectRequireRefs } from '../src/transform-worker';
+import { runSwc } from '../src/swc';
 import type { JsTransformerConfig, JsTransformOptions } from '../src/types';
 
 const baseConfig: JsTransformerConfig = {
@@ -46,6 +50,48 @@ const baseTransformOptions: JsTransformOptions = {
   type: 'module',
   unstable_transformProfile: 'default',
 };
+
+describe('Expo manifest env', () => {
+  test('inlines process.env.APP_MANIFEST for web transforms', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'rn-swc-expo-manifest-'));
+    try {
+      writeFileSync(join(projectRoot, 'package.json'), JSON.stringify({ name: 'manifest-test' }));
+      writeFileSync(
+        join(projectRoot, 'app.json'),
+        JSON.stringify({
+          expo: {
+            name: 'Native Name',
+            slug: 'manifest-test',
+            orientation: 'portrait',
+            ios: { bundleIdentifier: 'dev.example.app' },
+            android: { package: 'dev.example.app' },
+            hooks: { postPublish: [] },
+            web: { shortName: 'Web Name' },
+            extra: { apiBase: 'https://api.example.test' },
+          },
+        }),
+      );
+
+      const { code } = runSwc(
+        'export const manifest = process.env.APP_MANIFEST || {};',
+        join(projectRoot, 'index.js'),
+        {
+          ...baseTransformOptions,
+          platform: 'web',
+        } as JsTransformOptions,
+        undefined,
+        projectRoot,
+      );
+
+      expect(code).toContain('"apiBase":"https://api.example.test"');
+      expect(code).toContain('"shortName":"Web Name"');
+      expect(code).not.toContain('bundleIdentifier');
+      expect(code).not.toContain('postPublish');
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // collectRequireRefs / transformRequires — project-specific helper behaviour

--- a/packages/core/src/expo-inline-manifest.ts
+++ b/packages/core/src/expo-inline-manifest.ts
@@ -1,0 +1,164 @@
+const RESTRICTED_MANIFEST_FIELDS = [
+  'androidNavigationBar',
+  'androidStatusBar',
+  'privacy',
+  // Remove iOS and Android.
+  'ios',
+  'android',
+  // Hide internal / build values
+  'plugins',
+  'hooks', // hooks no longer exists in the typescript type but should still be removed
+  '_internal',
+  // Remove metro-specific values
+  'assetBundlePatterns',
+] as const;
+
+let configMemo: ExpoConfigMemo | null | undefined;
+
+export function getExpoAppManifest(projectRoot: string): string | null {
+  if (process.env.APP_MANIFEST) {
+    return process.env.APP_MANIFEST;
+  }
+
+  const exp = getExpoConstantsManifest(projectRoot);
+  if (exp) {
+    return JSON.stringify(exp);
+  }
+  return null;
+}
+
+function getExpoConstantsManifest(projectRoot: string): ExpoConfigRecord | null {
+  const config = getConfigMemo(projectRoot);
+  if (!config) return null;
+
+  const manifest = applyWebDefaults(config);
+
+  for (const field of RESTRICTED_MANIFEST_FIELDS) {
+    delete manifest[field];
+  }
+
+  return manifest;
+}
+
+function getConfigMemo(projectRoot: string): ExpoConfigMemo | null {
+  if (configMemo !== undefined) {
+    return configMemo;
+  }
+
+  let expoConfig: unknown;
+  try {
+    // This is an optional dependency. In practice, it will resolve in all Expo projects/apps
+    // since `expo` is a direct dependency in those. If this package is used independently
+    // this will fail and we won't return a config.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    expoConfig = require('expo/config');
+  } catch (error) {
+    if (isModuleNotFound(error)) {
+      return (configMemo = null);
+    }
+    throw error;
+  }
+
+  const { getConfig, getNameFromConfig } = expoConfig as {
+    getConfig: (
+      root: string,
+      options: { isPublicConfig: boolean; skipSDKVersionRequirement: boolean },
+    ) => { exp: ExpoConfigRecord };
+    getNameFromConfig: (config: ExpoConfigRecord) => { appName: string; webName: string };
+  };
+
+  const config = getConfig(projectRoot, {
+    isPublicConfig: true,
+    skipSDKVersionRequirement: true,
+  });
+  // rn-cli apps use a displayName value as well.
+  const { appName, webName } = getNameFromConfig(config.exp);
+  return (configMemo = {
+    config,
+    appName,
+    webName,
+  });
+}
+
+type ExpoConfigRecord = Record<string, any>;
+
+interface ExpoConfigMemo {
+  config: { exp: ExpoConfigRecord };
+  appName: string;
+  webName: string;
+}
+
+function applyWebDefaults({ config, appName, webName }: ExpoConfigMemo): ExpoConfigRecord {
+  const appJSON = config.exp;
+  // For RN CLI support
+  const webManifest = appJSON.web ?? {};
+  const splash = appJSON.splash ?? {};
+  const ios = appJSON.ios ?? {};
+  const android = appJSON.android ?? {};
+  const languageISOCode = webManifest.lang;
+  const primaryColor = appJSON.primaryColor;
+  const description = appJSON.description;
+  // The theme_color sets the color of the tool bar, and may be reflected in the app's preview in task switchers.
+  const webThemeColor = webManifest.themeColor || primaryColor;
+  const dir = webManifest.dir;
+  const shortName = webManifest.shortName || webName;
+  const display = webManifest.display;
+  const startUrl = webManifest.startUrl;
+  const { scope, crossorigin } = webManifest;
+  const barStyle = webManifest.barStyle;
+  const orientation = ensurePWAOrientation(webManifest.orientation || appJSON.orientation);
+  /**
+   * **Splash screen background color**
+   * `https://developers.google.com/web/fundamentals/web-app-manifest/#splash-screen`
+   * The background_color should be the same color as the load page,
+   * to provide a smooth transition from the splash screen to your app.
+   */
+  const backgroundColor = webManifest.backgroundColor || splash.backgroundColor; // No default background color
+
+  return {
+    ...appJSON,
+    name: appName,
+    description,
+    primaryColor,
+    ios: { ...ios },
+    android: { ...android },
+    web: {
+      ...webManifest,
+      meta: undefined,
+      build: undefined,
+      scope,
+      crossorigin,
+      description,
+      startUrl,
+      shortName,
+      display,
+      orientation,
+      dir,
+      barStyle,
+      backgroundColor,
+      themeColor: webThemeColor,
+      lang: languageISOCode,
+      name: webName,
+    },
+  };
+}
+
+// Convert expo value to PWA value
+function ensurePWAOrientation(orientation: unknown): string | undefined {
+  if (orientation) {
+    const webOrientation = String(orientation).toLowerCase();
+    if (webOrientation !== 'default') {
+      return webOrientation;
+    }
+  }
+  return undefined;
+}
+
+function isModuleNotFound(error: unknown): error is { code: 'MODULE_NOT_FOUND' } {
+  return (
+    typeof error === 'object' &&
+    error != null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'MODULE_NOT_FOUND'
+  );
+}

--- a/packages/core/src/swc.ts
+++ b/packages/core/src/swc.ts
@@ -13,6 +13,7 @@ import {
   type ReactConfig,
 } from '@swc/core';
 
+import { getExpoAppManifest } from './expo-inline-manifest';
 import { decodeRawSourceMap } from './source-map';
 import type {
   ExtendedParserConfig,
@@ -98,17 +99,28 @@ function buildInlineEnvs(
   options: JsTransformOptions,
   filename: string,
   userConfig: SwcTransformerOptions | undefined,
+  projectRoot: string | undefined,
 ): Record<string, string> {
   const { dev, platform, customTransformOptions } = options;
-  const projectRoot = (options as unknown as { projectRoot?: string }).projectRoot;
+  const possibleProjectRoot =
+    projectRoot ?? (options as unknown as { projectRoot?: string }).projectRoot ?? '';
+  const environment = customTransformOptions?.environment;
+  const shouldInlineManifest = platform === 'web' || environment === 'react-server';
 
   const envs: Record<string, string> = {
     NODE_ENV: dev ? 'development' : 'production',
     EXPO_OS: platform ?? '',
   };
 
-  if (projectRoot) {
-    envs.EXPO_PROJECT_ROOT = projectRoot;
+  if (shouldInlineManifest) {
+    const manifest = getExpoAppManifest(possibleProjectRoot);
+    if (manifest != null) {
+      envs.APP_MANIFEST = manifest;
+    }
+  }
+
+  if (possibleProjectRoot) {
+    envs.EXPO_PROJECT_ROOT = possibleProjectRoot;
 
     const routerRoot =
       typeof customTransformOptions?.routerRoot === 'string'
@@ -117,7 +129,7 @@ function buildInlineEnvs(
     const asyncRoutes =
       customTransformOptions?.asyncRoutes === 'true' ||
       customTransformOptions?.asyncRoutes === true;
-    const absAppRoot = join(projectRoot, routerRoot);
+    const absAppRoot = join(possibleProjectRoot, routerRoot);
 
     envs.EXPO_ROUTER_APP_ROOT = relative(dirname(filename), absAppRoot);
     envs.EXPO_ROUTER_ABS_APP_ROOT = absAppRoot;
@@ -248,9 +260,10 @@ export function runSwc(
   filename: string,
   options: JsTransformOptions,
   userConfig: SwcTransformerOptions | undefined,
+  projectRoot?: string,
 ): { code: string; map: MetroSourceMapSegmentTuple[] } {
   const { dev } = options;
-  const envs = buildInlineEnvs(options, filename, userConfig);
+  const envs = buildInlineEnvs(options, filename, userConfig, projectRoot);
 
   const reactConfig: ReactConfig = {
     runtime: 'automatic',

--- a/packages/core/src/transform-worker.ts
+++ b/packages/core/src/transform-worker.ts
@@ -70,7 +70,7 @@ export const transform = async (
     ? generateCodegenSource(filename, sourceCode)
     : sourceCode;
 
-  const { code, map } = runSwc(origSrc, filename, options, config.swcConfig);
+  const { code, map } = runSwc(origSrc, filename, options, config.swcConfig, projectRoot);
 
   const jsType: JSFileType = options.type === 'script' ? 'js/script' : 'js/module';
 


### PR DESCRIPTION
Fixes #7

## Summary

This mirrors Expo's `expo-inline-manifest-plugin` behavior in the SWC transform path.

For web and React Server transforms, `process.env.APP_MANIFEST` is now replaced with the serialized public Expo app manifest. This allows `expo-constants` on web to populate `Constants.expoConfig`, including `extra`.

## Changes

- Add `expo-inline-manifest.ts`, modeled after Expo's inline manifest plugin.
- Pass `projectRoot` from the Metro transform worker into `runSwc`.
- Include `APP_MANIFEST` in the SWC inline env map for web / React Server transforms.
- Add a regression test covering `Constants.expoConfig.extra`-style values and restricted manifest fields.

## Verification

- `pnpm --filter @react-native-swc/core test`
- `pnpm --filter @react-native-swc/core typecheck`
- `pnpm --filter @react-native-swc/core build:ts`
- `pnpm exec oxfmt --check packages/core/src/swc.ts packages/core/src/expo-inline-manifest.ts packages/core/src/transform-worker.ts packages/core/__tests__/transform-worker.test.ts`

Also verified in a real Expo web app by pointing Metro at the local fork build:

- web bundle succeeds
- `process.env.APP_MANIFEST` is removed from the bundle
- `Constants.expoConfig.extra` values are present
- browser runtime reaches the app's first screen with no page errors
