### PR TITLE
Support metro config as async factories

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,8 @@
-import type { MetroConfig } from 'metro-config';
+import type { MetroConfig } from "metro-config";
 
-import type { SwcTransformerOptions } from './transform-worker';
+import type { SwcTransformerOptions } from "./transform-worker";
 
-export type { SwcTransformerOptions } from './transform-worker';
+export type { SwcTransformerOptions } from "./transform-worker";
 
 // ---------------------------------------------------------------------------
 // Metro config helper
@@ -34,19 +34,22 @@ export type { SwcTransformerOptions } from './transform-worker';
  * ```
  */
 export function withSwcTransformer(
-  config: MetroConfig,
+  config: MetroConfig | Promise<MetroConfig>,
   swcConfig?: SwcTransformerOptions,
-): MetroConfig {
-  return {
-    ...config,
-    transformerPath: require.resolve('./transform-worker'),
-    transformer: {
-      ...config.transformer,
-      minifierPath: require.resolve('./minifier'),
-      minifierConfig: {
-        ...config.transformer?.minifierConfig,
+): () => Promise<MetroConfig> {
+  return async function () {
+    const resolvedConfig = await config;
+    return {
+      ...resolvedConfig,
+      transformerPath: require.resolve("./transform-worker"),
+      transformer: {
+        ...resolvedConfig.transformer,
+        minifierPath: require.resolve("./minifier"),
+        minifierConfig: {
+          ...resolvedConfig.transformer?.minifierConfig,
+        },
+        ...(swcConfig ? { swcConfig } : {}),
       },
-      ...(swcConfig ? { swcConfig } : {}),
-    },
+    };
   };
 }


### PR DESCRIPTION
This PR adds support for async input configs in `withSwcTransformer`.

Metro configs can be simple exported objects, factories, or async factories (see [mergeConfig types](https://github.com/facebook/metro/blob/324d986283ec36ac958c386a60ab5f714b05ac2b/packages/metro-config/src/loadConfig.js#L202)). Rozenite also supports async configs in its [withRozenite](https://github.com/callstackincubator/rozenite/blob/60a157e4eb3a2b894bafa50decc1e04eb8b19374/packages/metro/src/index.ts#L33-L38) metro config wrapper. 
