### PR TITLE
Support async metro config

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,21 @@ export type { SwcTransformerOptions } from './transform-worker';
 // Metro config helper
 // ---------------------------------------------------------------------------
 
+function applySwcTransformer(config: MetroConfig, swcConfig?: SwcTransformerOptions): MetroConfig {
+  return {
+    ...config,
+    transformerPath: require.resolve('./transform-worker'),
+    transformer: {
+      ...config.transformer,
+      minifierPath: require.resolve('./minifier'),
+      minifierConfig: {
+        ...config.transformer?.minifierConfig,
+      },
+      ...(swcConfig ? { swcConfig } : {}),
+    },
+  };
+}
+
 /**
  * Wrap a Metro configuration object so that SWC is used for transpilation
  * and minification.
@@ -33,20 +48,12 @@ export type { SwcTransformerOptions } from './transform-worker';
  * );
  * ```
  */
-export function withSwcTransformer(
-  config: MetroConfig,
+export function withSwcTransformer<T extends MetroConfig | Promise<MetroConfig>>(
+  config: T,
   swcConfig?: SwcTransformerOptions,
-): MetroConfig {
-  return {
-    ...config,
-    transformerPath: require.resolve('./transform-worker'),
-    transformer: {
-      ...config.transformer,
-      minifierPath: require.resolve('./minifier'),
-      minifierConfig: {
-        ...config.transformer?.minifierConfig,
-      },
-      ...(swcConfig ? { swcConfig } : {}),
-    },
-  };
+): T {
+  if ('then' in config) {
+    return config.then((resolvedConfig) => applySwcTransformer(resolvedConfig, swcConfig)) as T;
+  }
+  return applySwcTransformer(config, swcConfig) as T;
 }


### PR DESCRIPTION
Using rozenite will "taint" a regular config object by making it promise wrapped even if your config isn't async. This PR adds support for async configs, but without making it a promise unless it already is one. 

Supersedes https://github.com/oblador/react-native-swc/pull/11