### PR TITLE
Push inline-requires scope for class constructors

### DIFF
--- a/packages/metro-plugin/__tests__/inline-requires.test.ts
+++ b/packages/metro-plugin/__tests__/inline-requires.test.ts
@@ -174,6 +174,35 @@ describe('memoizeCalls=false:', () => {
     compareInlineRequires(code, code, opts);
   });
 
+  test('does not inline a candidate shadowed by a class constructor parameter', () => {
+    // `Constructor` is its own AST node (not a `Function`)
+    const code = [
+      'var foo = require("foo");',
+      'class C {',
+      '  constructor(foo) {',
+      '    this.bar = foo.bar;',
+      '  }',
+      '}',
+    ].join('\n');
+    compareInlineRequires(code, code, opts);
+  });
+
+  test('does not inline a candidate shadowed by a class method parameter', () => {
+    // Companion to the constructor regression — class methods route through
+    // `visit_mut_function` (their inner `function` is a real `Function`
+    // node), but it's worth pinning the behaviour explicitly so a future
+    // visitor refactor doesn't quietly regress it.
+    const code = [
+      'var foo = require("foo");',
+      'class C {',
+      '  m(foo) {',
+      '    return foo.bar;',
+      '  }',
+      '}',
+    ].join('\n');
+    compareInlineRequires(code, code, opts);
+  });
+
   test('does not transform require calls that are already inline', () => {
     const code = `
         function test() {

--- a/packages/metro-plugin/crates/metro_plugin/src/inline_requires.rs
+++ b/packages/metro-plugin/crates/metro_plugin/src/inline_requires.rs
@@ -542,6 +542,48 @@ impl<'a> VisitMut for InlineReplacer<'a> {
         self.pop_scope();
     }
 
+    fn visit_mut_constructor(&mut self, ctor: &mut Constructor) {
+        self.push_scope(true);
+        for param in &ctor.params {
+            match param {
+                ParamOrTsParamProp::Param(p) => {
+                    collect_pat_atoms(&p.pat, &mut |n| {
+                        if self.inlineable_calls.contains(n) {
+                            self.requires_shadowed += 1;
+                        }
+                        self.declare_local(n.clone());
+                    });
+                }
+                ParamOrTsParamProp::TsParamProp(p) => {
+                    let name = match &p.param {
+                        TsParamPropParam::Ident(bi) => bi.id.sym.clone(),
+                        TsParamPropParam::Assign(a) => {
+                            if let Pat::Ident(bi) = a.left.as_ref() {
+                                bi.id.sym.clone()
+                            } else {
+                                continue;
+                            }
+                        }
+                    };
+                    if self.inlineable_calls.contains(&name) {
+                        self.requires_shadowed += 1;
+                    }
+                    self.declare_local(name);
+                }
+            }
+        }
+        if let Some(body) = &ctor.body {
+            collect_fn_var_atoms(body, &mut |n| {
+                if self.inlineable_calls.contains(n) {
+                    self.requires_shadowed += 1;
+                }
+                self.declare_local(n.clone());
+            });
+        }
+        ctor.visit_mut_children_with(self);
+        self.pop_scope();
+    }
+
     fn visit_mut_block_stmt(&mut self, block: &mut BlockStmt) {
         self.push_scope(false);
         collect_block_lexical_atoms(block, &mut |n| {


### PR DESCRIPTION
Class `Constructor` is its own AST node, not a `Function`, so the existing `visit_mut_function` handler never declared its params as locally scoped. 